### PR TITLE
docs: Fix a few typos

### DIFF
--- a/mindwave/bluetooth_headset.py
+++ b/mindwave/bluetooth_headset.py
@@ -22,7 +22,7 @@ def connect_magic():
         If this computer hasn't connected to the headset before, you may need
         to make it visible to this computer's bluetooth adapter. This is done
         by pushing the switch on the left side of the headset to the "on/pair"
-        position until the blinking rythm switches.
+        position until the blinking rhythm switches.
 
         The address is then put in a file for later reference.
 

--- a/mindwave/pyeeg.py
+++ b/mindwave/pyeeg.py
@@ -587,7 +587,7 @@ def ap_entropy(X, M, R):
 	as Em = embed_seq(X, 1, M). Then we build matrix Emp, whose only 
 	difference with Em is that the length of each embedding sequence is M + 1
 
-	Denote the i-th and j-th row of Em as Em[i] and Em[j]. Their k-th elments 
+	Denote the i-th and j-th row of Em as Em[i] and Em[j]. Their k-th elements 
 	are	Em[i][k] and Em[j][k] respectively. The distance between Em[i] and Em[j]
 	is defined as 1) the maximum difference of their corresponding scalar 
 	components, thus, max(Em[i]-Em[j]), or 2) Euclidean distance. We say two 1-D
@@ -621,7 +621,7 @@ def ap_entropy(X, M, R):
 	References
 	----------
 
-	Costa M, Goldberger AL, Peng CK, Multiscale entropy analysis of biolgical
+	Costa M, Goldberger AL, Peng CK, Multiscale entropy analysis of biological
 	signals, Physical Review E, 71:021906, 2005
 
 	See also
@@ -683,7 +683,7 @@ def samp_entropy(X, M, R):
 	as Em = embed_seq(X, 1, M). Then we build matrix Emp, whose only 
 	difference with Em is that the length of each embedding sequence is M + 1
 
-	Denote the i-th and j-th row of Em as Em[i] and Em[j]. Their k-th elments 
+	Denote the i-th and j-th row of Em as Em[i] and Em[j]. Their k-th elements 
 	are	Em[i][k] and Em[j][k] respectively. The distance between Em[i] and Em[j]
 	is defined as 1) the maximum difference of their corresponding scalar 
 	components, thus, max(Em[i]-Em[j]), or 2) Euclidean distance. We say two 1-D
@@ -703,7 +703,7 @@ def samp_entropy(X, M, R):
 	References
 	----------
 
-	Costa M, Goldberger AL, Peng C-K, Multiscale entropy analysis of biolgical
+	Costa M, Goldberger AL, Peng C-K, Multiscale entropy analysis of biological
 	signals, Physical Review E, 71:021906, 2005
 
 	See also
@@ -746,7 +746,7 @@ def dfa(X, Ave = None, L = None):
 	The first step to compute DFA is to integrate the signal. Let original seres
 	be X= [x(1), x(2), ..., x(N)]. 
 
-	The integrated signal Y = [y(1), y(2), ..., y(N)] is otained as follows
+	The integrated signal Y = [y(1), y(2), ..., y(N)] is obtained as follows
 	y(k) = \sum_{i=1}^{k}{x(i)-Ave} where Ave is the mean of X. 
 
 	The second step is to partition/slice/segment the integrated sequence Y into


### PR DESCRIPTION
There are small typos in:
- mindwave/bluetooth_headset.py
- mindwave/pyeeg.py

Fixes:
- Should read `elements` rather than `elments`.
- Should read `biological` rather than `biolgical`.
- Should read `rhythm` rather than `rythm`.
- Should read `obtained` rather than `otained`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md